### PR TITLE
Disable cert verification when requesting weather and search service data

### DIFF
--- a/apps/campus/models.py
+++ b/apps/campus/models.py
@@ -541,7 +541,8 @@ class DiningLocation(MapObj):
             try:
                 page = requests.get(settings.PHONEBOOK,
                                     params=params,
-                                    timeout=settings.REQUEST_TIMEOUT)
+                                    timeout=settings.REQUEST_TIMEOUT,
+                                    verify=False)
             except Exception, e:
                 log.error('Unable to open URL %s: %s' % (settings.PHONEBOOK, str(e)))
             else:

--- a/apps/campus/views.py
+++ b/apps/campus/views.py
@@ -867,7 +867,8 @@ def weather(request):
     '''
     try:
         response = requests.get(settings.WEATHER_URL,
-                                timeout=settings.REQUEST_TIMEOUT).json()
+                                timeout=settings.REQUEST_TIMEOUT,
+                                verify=False).json()
 
 
         w_json = {"temperature": u'{0}\u00B0F'.format(response['tempN']), "description": response['condition']}

--- a/apps/views.py
+++ b/apps/views.py
@@ -154,7 +154,8 @@ def organization_search(q):
     try:
         results = requests.get(settings.PHONEBOOK,
                                params=params,
-                               timeout=settings.REQUEST_TIMEOUT).json()
+                               timeout=settings.REQUEST_TIMEOUT,
+                               verify=False).json()
         return results
     except:
         logger.error('Issue with organization search service')
@@ -170,7 +171,8 @@ class Orgs:
         try:
             orgs = requests.get(settings.PHONEBOOK,
                                 params=payload,
-                                timeout=settings.REQUEST_TIMEOUT).json()
+                                timeout=settings.REQUEST_TIMEOUT,
+                                verify=False).json()
             cls.data = orgs
             return True
         except:
@@ -191,7 +193,8 @@ def get_depts():
     try:
         depts = requests.get(settings.PHONEBOOK,
                              params=payload,
-                             timeout=settings.REQUEST_TIMEOUT).json()
+                             timeout=settings.REQUEST_TIMEOUT,
+                             verify=False).json()
     except:
         print "Issue with phonebook search service"
         return None
@@ -215,7 +218,8 @@ def phonebook_search(q):
     try:
         results = requests.get(settings.PHONEBOOK,
                                params={'search': q},
-                               timeout=settings.REQUEST_TIMEOUT).json()
+                               timeout=settings.REQUEST_TIMEOUT,
+                               verify=False).json()
         return results
     except:
         print "Issue with phonebook search service"
@@ -225,7 +229,7 @@ def phonebook_search(q):
 def group_search(q):
     groups = campus.models.Group.objects.filter(name__icontains=q)
     return groups
-    
+
 def search(request):
     '''
     one day will search over all data available
@@ -279,7 +283,7 @@ def search(request):
                 'name': item.name,
                 'id': item.pk,
                 'link': item.link}
-        
+
         def extended_meta(item):
             return item.json()
 

--- a/settings.py
+++ b/settings.py
@@ -209,7 +209,7 @@ GOOGLE_LOOK_HERE = "https://map.ucf.edu"
 SEARCH_ENGINE = None
 
 # Phonebook search service url
-PHONEBOOK = "http://search.smca.ucf.edu/service.php"
+PHONEBOOK = "https://search.smca.ucf.edu/service.php"
 
 LOGIN_REDIRECT_URL = '/admin/'
 


### PR DESCRIPTION
Temporary hotfix to disable cert verification when requesting data from UCF's weather and search services to allow those requests to return successfully.  Also updates the search service URL to https in settings.py.