### PR TITLE
Removed base_url prefix from info window templates for buildings and dining locations

### DIFF
--- a/templates/api/info_win_building.djt
+++ b/templates/api/info_win_building.djt
@@ -6,9 +6,9 @@
 
 {% else %}
 
-	<a href="{{ base_url }}{{ location.profile_link }}" class="item">{{ location.name }}</a>
+	<a href="{{ location.profile_link }}" class="item">{{ location.name }}</a>
 
-	<a class="item" href="{{ base_url }}{{ location.profile_link }}">
+	<a class="item" href="{{ location.profile_link }}">
 		{% if location.image %}
 			<img src="{{ location.image.url }}">
 		{%else%}

--- a/templates/api/info_win_dininglocation.djt
+++ b/templates/api/info_win_dininglocation.djt
@@ -6,9 +6,9 @@
 
 {% else %}
 
-	<a href="{{ base_url }}{{ location.profile_link }}" class="item">{{ location.name }}</a>
+	<a href="{{ location.profile_link }}" class="item">{{ location.name }}</a>
 
-	<a class="item" href="{{ base_url }}{{ location.profile_link }}">
+	<a class="item" href="{{ location.profile_link }}">
 		{% if location.image %}
 			<img src="{{ location.image.url }}">
 		{%else%}


### PR DESCRIPTION
Fixes issue with broken location profile URLs after searching + clicking on a location from the search bar, then trying to click to view the location profile from the right-hand information window.