### PR TITLE
Removed email link

### DIFF
--- a/templates/pages/printable.djt
+++ b/templates/pages/printable.djt
@@ -10,7 +10,6 @@
 <div>
     <h2>Printable Map</h2>
     <p>All printable maps require <a href="http://get.adobe.com/reader/">Adobe Reader</a>.</p>
-    <p>For an accessible version of UCF Campus Maps, contact <a href="mailto:atservices@ucf.edu">atservices@ucf.edu</a>.</p>
 </div>
 <div>
     <div class="printable">


### PR DESCRIPTION
Removed atservices blurb/email link on the printable maps page by request.