### PR TITLE
Fixed 'view all' links under group, org, and building lists in the sidebar window

### DIFF
--- a/templates/api/info_win_building.djt
+++ b/templates/api/info_win_building.djt
@@ -35,7 +35,7 @@
 			<li><a href="{{ base_url }}{% url 'locations' %}/{{ o.bldg_id }}/{{ o.building|slugify }}/?org={{ o.id }}">{{ o.name }}</a></li>
 			{% endif %}
 			{% if forloop.counter == 5  %}
-				<li class="c"><a href="{{ base_url }}{{ location.profile_link }}">-- View All --</a></li>
+				<li class="c"><a href="{{ location.profile_link }}">-- View All --</a></li>
 			{% endif %}
 		{% endfor %}
 		</ul>

--- a/templates/api/info_win_group.djt
+++ b/templates/api/info_win_group.djt
@@ -33,7 +33,7 @@
 			<li><a href="{{ base_url }}/?show={{ l.id }}" onclick="return Campus.infoBox.show('{{ l.name }}', {{ l.googlemap_point }}, '{{ l.profile_link }}');">{{ l.name }}</a></li>
 		{% endfor %}
 		{% if group.overflow %}
-			<li class="c"><a href="{{ base_url }}{{ location.profile_link }}">-- View All --</a></li>
+			<li class="c"><a href="{{ location.profile_link }}">-- View All --</a></li>
 		{% endif %}
 		</ul>
 	</div>

--- a/templates/api/info_win_parkinglot.djt
+++ b/templates/api/info_win_parkinglot.djt
@@ -40,7 +40,7 @@
 			<li><a href="{{ base_url }}{% url 'locations' %}/{{ o.bldg_id }}/{{ o.building|slugify }}/?org={{ o.id }}">{{ o.name }}</a></li>
 		{% endfor %}
 		{% if location.orgs.overflow %}
-			<li class="c"><a href="{{ base_url }}{{ location.profile_link }}">-- View All --</a></li>
+			<li class="c"><a href="{{ location.profile_link }}">-- View All --</a></li>
 		{% endif %}
 		</ul>
 	</div>


### PR DESCRIPTION
Fixes invalid 'view all' link URLs visible when the user searches for a group/org/building in the top-left search field (e.g. "millican") and clicks the search result.  When the list of groups/orgs in the sidebar window is too long, a "View All" link is present whose URL is broken due to `{{ base_url }}` being unnecessarily included in the href value.